### PR TITLE
docs(parsers): fix Text Parser signature

### DIFF
--- a/parsers.html
+++ b/parsers.html
@@ -366,7 +366,7 @@
           <p>A valid schedule can be generated simple text expressions.</p>
 
           <br/>
-          <h4>later.parse.text(<i>expr</i>, <i>hasSeconds</i>)</h4>
+          <h4>later.parse.text(<i>expr</i>)</h4>
           <p>Parses the text expression <code>expr</code> and returns a valid schedule that
             can be used with Later.</p>
 


### PR DESCRIPTION
by removing the extra 2nd argument "hasSeconds" which is used only for Cron Parser.

Fix #11